### PR TITLE
Add setState(updater[, callback]) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ class Buttons extends React.Component {
     return (
       <div>
         <button onClick={this.handleClick(1)}>+</button>
-        <button onClick={this.handleClick(1)}>-</button>
+        <button onClick={this.handleClick(-1)}>-</button>
       </div>
     );
   }

--- a/package.json
+++ b/package.json
@@ -17,18 +17,18 @@
     ]
   },
   "dependencies": {
-    "hoist-non-react-statics": "^2.3.1",
-    "prop-types": "^15.6.0",
+    "hoist-non-react-statics": "^2.5.4",
+    "prop-types": "^15.6.1",
     "shallowequal": "^1.0.2"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
-    "babel-preset-env": "^1.6.0",
+    "babel-preset-env": "^1.7.0",
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-0": "^6.24.1",
-    "enzyme": "^3.1.0",
-    "enzyme-adapter-react-16": "^1.0.2",
-    "jest": "^21.2.1",
+    "enzyme": "^3.3.0",
+    "enzyme-adapter-react-16": "^1.1.1",
+    "jest": "^23.1.0",
     "react": "^16.0.0",
     "react-dom": "^16.0.0"
   }

--- a/src/connect.jsx
+++ b/src/connect.jsx
@@ -71,17 +71,14 @@ export default function connect(mapStateToProps) {
       }
 
       render() {
-        let props = {
+        const props = {
           ...this.props,
           ...this.state.subscribed,
           store: this.store,
         };
 
         if (!isStateless(WrappedComponent)) {
-          props = {
-            ...props,
-            ref: (c) => this.wrappedInstance = c,
-          };
+          props.ref = (c) => this.wrappedInstance = c;
         }
 
         return <WrappedComponent {...props}/>;

--- a/src/connect.jsx
+++ b/src/connect.jsx
@@ -40,22 +40,22 @@ export default function connect(mapStateToProps) {
         this.tryUnsubscribe();
       }
 
-      handleChange = () => {
+      handleChange = (state, callback) => {
         if (!this.unsubscribe) {
           return;
         }
 
-        const nextState = finnalMapStateToProps(this.store.getState(), this.props);
+        const nextState = finnalMapStateToProps(state, this.props);
         if (!shallowEqual(this.nextState, nextState)) {
           this.nextState = nextState;
-          this.setState({ subscribed: nextState });
+          this.setState({ subscribed: nextState }, callback);
         }
       };
 
       trySubscribe() {
         if (shouldSubscribe) {
           this.unsubscribe = this.store.subscribe(this.handleChange);
-          this.handleChange();
+          this.handleChange(this.store.getState());
         }
       }
 

--- a/src/create.js
+++ b/src/create.js
@@ -2,10 +2,14 @@ export default function create(initialState) {
   let state = initialState;
   const listeners = [];
 
-  function setState(partial) {
-    state = { ...state, ...partial };
+  function setState(updater, callback) {
+    if (typeof updater === 'function') {
+      updater = updater(state);
+    }
+
+    state = { ...state, ...updater };
     for (let i = 0; i < listeners.length; i++) {
-      listeners[i]();
+      listeners[i](state, callback);
     }
   }
 

--- a/src/create.js
+++ b/src/create.js
@@ -22,7 +22,7 @@ export default function create(initialState) {
 
     return function unsubscribe() {
       const index = listeners.indexOf(listener);
-      listeners.splice(index, 1);
+      index !== -1 && listeners.splice(index, 1);
     };
   }
 

--- a/tests/connect.test.js
+++ b/tests/connect.test.js
@@ -73,6 +73,24 @@ describe('stateless', () => {
 
     expect(wrapper.text()).toBe('hello world');
   });
+
+  test('call a callback after setState', () => {
+    const onUpdate = jest.fn();
+
+    store.setState({ count: 2 }, onUpdate);
+
+    expect(onUpdate).toBeCalled();
+  });
+
+  test('accept setState with function', () => {
+    store.setState((state) => ({ count: 1 }));
+
+    expect(store.getState().count).toBe(1);
+
+    store.setState((state) => ({ count: 2, prevCount: state.count }));
+
+    expect(store.getState().prevCount).toBe(1);
+  });
 });
 
 describe('stateful', () => {


### PR DESCRIPTION
- 增加 `setState(updater[, callback])` 用法的支持， `updater` 支持函数写法
- 增加 `setState(updater[, callback])` 测试用例
- 更新依赖库版本

![tim 20180613221817](https://user-images.githubusercontent.com/1730277/41357363-939f3478-6f58-11e8-8ff3-d3118567d7b6.png)
